### PR TITLE
fix: add amazon.com.au region domains

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,8 @@
         "*://*.amazon.de/*",
         "*://*.amazon.fr/*",
         "*://*.amazon.ca/*",
-        "*://*.amazon.com/*"
+        "*://*.amazon.com/*",
+        "*://*.amazon.com.au/*"
       ]
     }
   ],
@@ -37,7 +38,8 @@
         "*://*.amazon.co.jp/vine/*",
         "*://*.amazon.de/vine/*",
         "*://*.amazon.fr/vine/*",
-        "*://*.amazon.es/vine/*"
+        "*://*.amazon.es/vine/*",
+        "*://*.amazon.com.au/vine/*"
       ],
       "js": ["contentScript.js"],
       "css": ["styles.css"],


### PR DESCRIPTION
Just adds `amazon.com.au` domain names into the two domain name-relevant areas of the extension manifest.

Tested locally, I was able to load the unpacked extension and successfully load an item that was previously stuck by the infinite spinner. I now have a nice lil camera lens on order thanks to this fix :) 

